### PR TITLE
Add EV only upgrade

### DIFF
--- a/src/components/formatter/BuildSettingsForm.vue
+++ b/src/components/formatter/BuildSettingsForm.vue
@@ -60,6 +60,7 @@ const trackWidthOptions = enumToOptions(TrackWidthType);
           <LimitedUpgradeSelect v-model="form.build.engine.intercooler" label="Intercooler" />
           <UpgradeSelect v-model="form.build.engine.oilCooling" label="Oil Cooling" />
           <UpgradeSelect v-model="form.build.engine.flywheel" label="Flywheel" />
+          <UpgradeSelect v-model="form.build.engine.motorAndBattery" label="Motor and Battery" />
           <RestrictorUpgradeSelect v-model="form.build.engine.restrictorPlate" label="Restrictor Plate" />
         </div>
       </div>

--- a/src/lib/base64Form.ts
+++ b/src/lib/base64Form.ts
@@ -5,6 +5,11 @@ import {
   SettingsForm,
 } from './types';
 
+const VALUE_COUNT_BEFORE_TIRE_PROFILE_UPDATE = 98;
+const VALUE_COUNT_BEFORE_MOTOR_AND_BATTERY_UPDATE = 100;
+const TIRE_PROFILE_SIZE_INDEX = 39;
+const MOTOR_AND_BATTERY_INDEX = 24;
+
 // Reverse mangleLookup
 // const unmangleKeyMap: Record<string, string> = Object
 //   .keys(mangleKeyMap)
@@ -188,8 +193,15 @@ function deserializeFlatObject(value: string): Record<string, never> {
    * If a link is before this was added, we need to
    * insert the values into the parsed array
    */
-  if (values.length === 98) {
-    values.splice(38, 0, 's' as never, 's' as never);
+  if (values.length === VALUE_COUNT_BEFORE_TIRE_PROFILE_UPDATE) {
+    values.splice(TIRE_PROFILE_SIZE_INDEX, 0, 's' as never, 's' as never);
+  }
+
+  /**
+   * Added Motor and Battery
+   */
+  if (values.length === VALUE_COUNT_BEFORE_MOTOR_AND_BATTERY_UPDATE) {
+    values.splice(MOTOR_AND_BATTERY_INDEX, 0, 'na' as never);
   }
 
   const flattenedForm: Record<string, never> = {};

--- a/src/lib/defaultForm.ts
+++ b/src/lib/defaultForm.ts
@@ -116,6 +116,7 @@ export default function getDefaultForm(): SettingsForm {
         intercooler: LimitedUpgrade.stock,
         oilCooling: Upgrade.stock,
         flywheel: Upgrade.stock,
+        motorAndBattery: Upgrade.na,
         restrictorPlate: RestrictorUpgrade.na,
       },
       platformAndHandling: {

--- a/src/lib/mangle-lookup.ts
+++ b/src/lib/mangle-lookup.ts
@@ -31,6 +31,7 @@ export const mangleKeyMap: Record<string, string> = {
   engine: 'ad',
   exhaust: 'ae',
   flywheel: 'af',
+  motorAndBattery: 'ci',
   front: 'ag',
   frontArb: 'ah',
   frontBumper: 'ai',

--- a/src/lib/testForm.ts
+++ b/src/lib/testForm.ts
@@ -121,6 +121,7 @@ export default function getTestForm(): SettingsForm {
         intercooler: LimitedUpgrade.stock,
         oilCooling: Upgrade.stock,
         flywheel: Upgrade.stock,
+        motorAndBattery: Upgrade.na,
         restrictorPlate: RestrictorUpgrade.na,
       },
       platformAndHandling: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -234,6 +234,7 @@ export interface EngineUpgrades extends BuildSectionUpgrades {
   intercooler: LimitedUpgrade; // sport and race only
   oilCooling: Upgrade;
   flywheel: Upgrade;
+  motorAndBattery: Upgrade;
   restrictorPlate: RestrictorUpgrade;
 }
 


### PR DESCRIPTION
Adds EV-only upgrade "Motor and battery", maintains backward compatibility with older URLs.