### PR TITLE
Various optimizations

### DIFF
--- a/src/components/formatter/horizon/FHBuildSetupForm.vue
+++ b/src/components/formatter/horizon/FHBuildSetupForm.vue
@@ -116,6 +116,10 @@ const trackWidthOptions = enumToOptions(TrackWidthType);
             v-model="form.build.engine.flywheel"
             label="Flywheel"
           />
+          <UpgradeSelect
+            v-model="form.build.engine.motorAndBattery"
+            label="Motor and Battery"
+          />
           <RestrictorUpgradeSelect
             v-model="form.build.engine.restrictorPlate"
             label="Restrictor Plate"

--- a/src/components/formatter/horizon/FHFormattedTuneTextarea.vue
+++ b/src/components/formatter/horizon/FHFormattedTuneTextarea.vue
@@ -18,7 +18,7 @@ const route = useRoute();
 const globalUnits = useGlobalUnits();
 
 const selectedFormat = ref<'reddit' | 'discord'>('reddit');
-const copyButtonText = ref('Copy text');
+const copyButtonText = ref('Copy To Clipboard');
 const copyUrlButtonText = ref('Copy URL');
 const errorText = ref('');
 
@@ -86,6 +86,11 @@ async function onShareURLClick() {
   }
 }
 
+function onFormatSelect(e: Event) {
+  selectedFormat.value = (e.target as HTMLInputElement).value as 'reddit' | 'discord';
+  localStorage.setItem('SELECTED_FORMATTER', selectedFormat.value);
+}
+
 </script>
 <template>
   <div class="actions">
@@ -96,6 +101,43 @@ async function onShareURLClick() {
     >
       {{ copyUrlButtonText }}
     </button>
+
+    <div class="flex justify-around mb-2">
+      <label class="radio cursor-pointer">
+        <input
+          :checked="selectedFormat === 'reddit'"
+          class="cursor-pointer"
+          type="radio"
+          name="generateFor"
+          value="reddit"
+          @input="onFormatSelect"
+        >
+        Reddit
+      </label>
+      <label class="radio cursor-pointer">
+        <input
+          :checked="selectedFormat === 'discord'"
+          class="cursor-pointer"
+          type="radio"
+          name="generateFor"
+          value="discord"
+          @input="onFormatSelect"
+        >
+        Discord
+      </label>
+    </div>
+
+    <p class="text-sm px-1 text-center mb-4">
+      <span class="text-yellow font-bold">NOTE:</span>
+      <template v-if="selectedFormat === 'reddit'">
+        Be sure the editor is in &quot;Markdown&quot; mode<br>
+        when creating your post on Reddit!
+      </template>
+      <template v-else>
+        Please also copy the URL and include it with your post!
+      </template>
+    </p>
+
     <button
       type="button"
       class="w-full secondary"
@@ -111,11 +153,6 @@ async function onShareURLClick() {
       rows="10"
       cols="25"
     />
-    <p class="text-sm text-light-mist px-1 text-center mb-10">
-      <strong class="text-yellow">NOTE:</strong>
-      Be sure the editor is in &quot;Markdown&quot; mode<br>
-      when creating your post on Reddit!
-    </p>
     <button
       type="button"
       class="w-full outlined"

--- a/src/components/formatter/horizon/FHSetup.ts
+++ b/src/components/formatter/horizon/FHSetup.ts
@@ -72,6 +72,7 @@ export interface EngineUpgrades extends BuildSectionUpgrades {
   intercooler: LimitedUpgrade; // sport and race only
   oilCooling: Upgrade;
   flywheel: Upgrade;
+  motorAndBattery: Upgrade;
   restrictorPlate: RestrictorUpgrade;
 }
 
@@ -276,6 +277,7 @@ export default function getFHDefaultFormV1(): FHSetup {
         intercooler: LimitedUpgrade.stock,
         oilCooling: Upgrade.stock,
         flywheel: Upgrade.stock,
+        motorAndBattery: Upgrade.na,
         restrictorPlate: RestrictorUpgrade.na,
       },
       platformAndHandling: {

--- a/src/components/formatter/horizon/fh-discord-generator.ts
+++ b/src/components/formatter/horizon/fh-discord-generator.ts
@@ -496,10 +496,10 @@ function formatStatistics(form: FHSetup, globalUnit: 'Metric' | 'Imperial') {
 
   const units = getUnitsForGlobalUnit(globalUnit);
 
-  if (form.stats.weight) stats.push(['Weight', ...formatUnitWithSeparator(form.stats.weight, units.weight, 0, true)]);
-  if (form.stats.balance) stats.push(['Balance', `${form.stats.balance}%`]);
   if (form.stats.hp) stats.push(['Power', ...formatUnitWithSeparator(form.stats.hp, units.power, 0, true)]);
   if (form.stats.torque) stats.push(['Torque', ...formatUnitWithSeparator(form.stats.torque, units.torque, 0, true)]);
+  if (form.stats.weight) stats.push(['Weight', ...formatUnitWithSeparator(form.stats.weight, units.weight, 0, true)]);
+  if (form.stats.balance) stats.push(['Balance', `${form.stats.balance}%`]);
   if (form.stats.topSpeed) stats.push(['Top Speed', ...formatUnitWithSeparator(form.stats.topSpeed, units.speed, 0, true)]);
   if (form.stats.zeroToSixty) stats.push(['0-60', `${form.stats.zeroToSixty}s`]);
   if (form.stats.zeroToHundred) stats.push(['0-100', `${form.stats.zeroToHundred}s`]);

--- a/src/components/formatter/motorsport/FMCarStatsForm.vue
+++ b/src/components/formatter/motorsport/FMCarStatsForm.vue
@@ -130,9 +130,6 @@ const balanceRear = computed(() => (form.stats.balance ? (100 - balance.value).t
           >
             <template #suffix>%</template>
           </NumberInput>
-          <div class="text-control">
-            &sol; {{ balanceRear }} %
-          </div>
         </div>
         <div class="set-upgrades">
           <NumberInput

--- a/src/components/formatter/motorsport/FMPerformanceUpgradesForm.vue
+++ b/src/components/formatter/motorsport/FMPerformanceUpgradesForm.vue
@@ -18,7 +18,6 @@ import UpgradeSelect from '../../UpgradeSelect.vue';
 import { useFMSetupForm } from './useFMSetupForm';
 
 const { form } = useFMSetupForm();
-const trackWidthOptions = enumToOptions(TrackWidthType);
 /*
 Fuel and Air
   Exhaust
@@ -212,25 +211,18 @@ Conversion
       <div class="content">
         <h3>Tires</h3>
         <div class="set-upgrades">
+          <FrontRearInputs
+            v-model="form.upgrades.tires.width"
+            label="Tire Width"
+          />
+        </div>
+        <div class="set-upgrades">
           <EnumSelect
             v-model="form.upgrades.tires.compound"
             label="Compound"
             :type="FMTireCompound"
           />
         </div>
-        <div class="set-upgrades">
-          <FrontRearInputs
-            v-model="form.upgrades.tires.width"
-            label="Tire Width"
-          />
-        </div>
-        <!-- <div class="set-upgrades">
-          <FrontRearSelects
-            v-model="form.upgrades.tires.trackWidth"
-            label="Track Width"
-            :options="trackWidthOptions"
-          />
-        </div> -->
       </div>
       <div class="content">
         <h3>Wheels</h3>
@@ -251,10 +243,6 @@ Conversion
       <div class="content">
         <h3>Drivetrain</h3>
         <div class="set-upgrades">
-          <UpgradeSelect
-            v-model="form.upgrades.drivetrain.clutch"
-            label="Clutch"
-          />
           <EnumSelect
             v-model="form.upgrades.drivetrain.transmission"
             label="Transmission"
@@ -267,6 +255,10 @@ Conversion
             :type="FMFullUpgrade"
           />
           <UpgradeSelect
+            v-model="form.upgrades.drivetrain.clutch"
+            label="Clutch"
+          />
+          <UpgradeSelect
             v-model="form.upgrades.drivetrain.driveline"
             label="Driveline"
           />
@@ -276,54 +268,38 @@ Conversion
         <h3>Aero and Appearance</h3>
         <div class="set-upgrades">
           <InputControl
-            v-model="form.upgrades.aeroAndAppearance.frontBumper"
-            label="Front Bumper"
-            class=""
-          />
-          <InputControl
-            v-model="form.upgrades.aeroAndAppearance.rearBumper"
-            label="Rear Bumper"
-            class=""
-          />
-        </div>
-        <div class="set-upgrades">
-          <InputControl
             v-model="form.upgrades.aeroAndAppearance.rearWing"
             label="Rear Wing"
             class=""
           />
           <InputControl
-            v-model="form.upgrades.aeroAndAppearance.sideSkirts"
-            label="Side Skirts"
+            v-model="form.upgrades.aeroAndAppearance.frontBumper"
+            label="Front Bumper"
             class=""
           />
         </div>
         <div class="set-upgrades">
+          <InputControl
+            v-model="form.upgrades.aeroAndAppearance.rearBumper"
+            label="Rear Bumper"
+            class=""
+          />
           <InputControl
             v-model="form.upgrades.aeroAndAppearance.hood"
             label="Hood"
             class=""
           />
         </div>
+        <div class="set-upgrades">
+          <InputControl
+            v-model="form.upgrades.aeroAndAppearance.sideSkirts"
+            label="Side Skirts"
+            class=""
+          />
+        </div>
       </div>
       <div class="content">
         <h3>Conversions</h3>
-        <div class="set-upgrades">
-          <InputControl
-            v-model="form.upgrades.conversions.engine"
-            label="Engine"
-            class="grow"
-          />
-
-          <EnumSelect
-            v-model="form.upgrades.conversions.drivetrain"
-            rootClass="grow"
-            label="Drivetrain"
-            note="(If stock, change it to the corresponding drivetype)"
-            :type="DriveType"
-            class="grow"
-          />
-        </div>
         <div class="set-upgrades">
           <InputControl
             v-model="form.upgrades.conversions.aspiration"
@@ -333,6 +309,21 @@ Conversion
           <InputControl
             v-model="form.upgrades.conversions.bodyKit"
             label="Body Kit"
+            class="grow"
+          />
+        </div>
+        <div class="set-upgrades">
+          <InputControl
+            v-model="form.upgrades.conversions.engine"
+            label="Engine"
+            class="grow"
+          />
+          <EnumSelect
+            v-model="form.upgrades.conversions.drivetrain"
+            rootClass="grow"
+            label="Drivetrain"
+            note="(If stock, change it to the corresponding drivetype)"
+            :type="DriveType"
             class="grow"
           />
         </div>

--- a/src/components/formatter/motorsport/FMPerformanceUpgradesForm.vue
+++ b/src/components/formatter/motorsport/FMPerformanceUpgradesForm.vue
@@ -4,9 +4,9 @@ import {
   DriveType,
   FMFullUpgrade,
   FMTireCompound,
+  LimitedTransmissionUpgrade,
   RimStyleType,
   TrackWidthType,
-  TransmissionUpgrade,
 } from '../../../lib/types';
 import { enumToOptions } from '../../../lib/utils';
 import EnumSelect from '../../EnumSelect.vue';
@@ -258,7 +258,7 @@ Conversion
           <EnumSelect
             v-model="form.upgrades.drivetrain.transmission"
             label="Transmission"
-            :type="TransmissionUpgrade"
+            :type="LimitedTransmissionUpgrade"
             rootClass="!min-w-[205px]"
           />
           <EnumSelect

--- a/src/components/formatter/motorsport/FMSetup.ts
+++ b/src/components/formatter/motorsport/FMSetup.ts
@@ -12,12 +12,12 @@ import {
   FrontAndRearWithUnits,
   GearTuneSettings,
   LengthUnit,
+  LimitedTransmissionUpgrade,
   LimitedUpgrade,
   PressureUnit,
   SpeedUnit,
   SpringRateUnit,
   TrackWidthType,
-  TransmissionUpgrade,
   Upgrade,
   WeightUnit,
 } from '../../../lib/types';
@@ -102,7 +102,7 @@ export interface TireUpgrades {
 
 export interface DrivetrainUpgrades {
   clutch: Upgrade;
-  transmission: TransmissionUpgrade;
+  transmission: LimitedTransmissionUpgrade;
   differential: FMFullUpgrade;
   driveline: Upgrade;
 }
@@ -267,7 +267,7 @@ function getFMDefaultFormV2(): FMSetup {
       },
       drivetrain: {
         clutch: Upgrade.stock,
-        transmission: TransmissionUpgrade.stock,
+        transmission: LimitedTransmissionUpgrade.stock,
         differential: FMFullUpgrade.stock,
         driveline: Upgrade.stock,
       },

--- a/src/components/formatter/motorsport/fm-discord-generator.ts
+++ b/src/components/formatter/motorsport/fm-discord-generator.ts
@@ -556,10 +556,10 @@ function formatStatistics(form: FMSetup, globalUnit: 'Metric' | 'Imperial') {
   const units = getUnitsForGlobalUnit(globalUnit);
 
   if (form.stats.carPoints) stats.push(['CP', `${form.stats.carPoints}`, '']);
-  if (form.stats.weight) stats.push(['Weight', ...formatUnitWithSeparator(form.stats.weight, units.weight, 0, true)]);
-  if (form.stats.balance) stats.push(['Balance', `${form.stats.balance}%`]);
   if (form.stats.hp) stats.push(['Power', ...formatUnitWithSeparator(form.stats.hp, units.power, 0, true)]);
   if (form.stats.torque) stats.push(['Torque', ...formatUnitWithSeparator(form.stats.torque, units.torque, 0, true)]);
+  if (form.stats.weight) stats.push(['Weight', ...formatUnitWithSeparator(form.stats.weight, units.weight, 0, true)]);
+  if (form.stats.balance) stats.push(['Balance', `${form.stats.balance}%`]);
   if (form.stats.topSpeed) stats.push(['Top Speed', ...formatUnitWithSeparator(form.stats.topSpeed, units.speed, 0, true)]);
   if (form.stats.zeroToSixty) stats.push(['0-60', `${form.stats.zeroToSixty}s`]);
   if (form.stats.zeroToHundred) stats.push(['0-100', `${form.stats.zeroToHundred}s`]);

--- a/src/components/formatter/motorsport/useFMEnabledControls.ts
+++ b/src/components/formatter/motorsport/useFMEnabledControls.ts
@@ -4,27 +4,17 @@ import {
   Ref,
 } from 'vue';
 
-import { DriveType, TransmissionUpgrade } from '../../../lib/types';
+import { DriveType, LimitedTransmissionUpgrade } from '../../../lib/types';
 
 import { FMSetup } from './FMSetup';
 
 const finalRatio = [
-  TransmissionUpgrade.sport,
-  TransmissionUpgrade.race,
-  TransmissionUpgrade.raceSix,
-  TransmissionUpgrade.raceSeven,
-  TransmissionUpgrade.raceEight,
-  TransmissionUpgrade.raceNine,
-  TransmissionUpgrade.raceTen,
+  LimitedTransmissionUpgrade.sport,
+  LimitedTransmissionUpgrade.race,
 ];
 
 const gearCounts: Record<string, number> = {
-  [TransmissionUpgrade.race]: 6,
-  [TransmissionUpgrade.raceSix]: 6,
-  [TransmissionUpgrade.raceSeven]: 7,
-  [TransmissionUpgrade.raceEight]: 8,
-  [TransmissionUpgrade.raceNine]: 9,
-  [TransmissionUpgrade.raceTen]: 10,
+  [LimitedTransmissionUpgrade.race]: 10,
 };
 
 export interface UseUpgrades {
@@ -39,8 +29,8 @@ export interface UseUpgrades {
   };
 }
 
-function getGearCount(transmission: TransmissionUpgrade): number {
-  return gearCounts[transmission] || 10;
+function getGearCount(transmission: LimitedTransmissionUpgrade): number {
+  return 10;
 }
 
 export default function useFMEnabledControls(form: FMSetup) {

--- a/src/lib/conversions.ts
+++ b/src/lib/conversions.ts
@@ -38,7 +38,7 @@ export const multipliersFromMetric: Record<string, number> = {
   [PressureUnit.bar]: 14.503773773,
   [ForceUnit.kgf]: 2.20462262185,
   [WeightUnit.kg]: 2.20462262185,
-  [SpringRateUnit.kgfmm]: 0.0867961665,
+  [SpringRateUnit.kgfmm]: 8.6796166500,
   [LengthUnit.cm]: 0.3937007874157,
   [SpeedUnit.kph]: 0.62137119223733,
   [PowerUnit.kw]: 1.341022089595,

--- a/src/lib/testForm.ts
+++ b/src/lib/testForm.ts
@@ -121,6 +121,7 @@ export default function getTestForm(): FHSetup {
         intercooler: LimitedUpgrade.stock,
         oilCooling: Upgrade.stock,
         flywheel: Upgrade.stock,
+        motorAndBattery: Upgrade.na,
         restrictorPlate: RestrictorUpgrade.na,
       },
       platformAndHandling: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -147,6 +147,13 @@ export enum TransmissionUpgrade {
   drift = 'Drift Four Speed',
 }
 
+export enum LimitedTransmissionUpgrade {
+  stock = 'Stock',
+  sport = 'Sport',
+  street = 'Street',
+  race = 'Race',
+}
+
 export enum FMTireCompound {
   stock = 'Stock',
   street = 'Street',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,13 +40,13 @@ export enum SpeedUnit {
 }
 
 export enum PowerUnit {
-  hp = 'HP',
   kw = 'kW',
+  hp = 'HP',
 }
 
 export enum TorqueUnit {
-  lbfft = 'lbf·ft',
   nm = 'N·m',
+  lbfft = 'lbf·ft',
 }
 
 export type UnitOfMeasureValues<U extends UnitOfMeasure, T extends string | number> = {

--- a/src/lib/useFormEncoder.ts
+++ b/src/lib/useFormEncoder.ts
@@ -2,6 +2,11 @@ import { compressToBase64, decompressFromBase64 } from 'lz-string';
 
 import { mangleValueMap } from './mangle-lookup';
 
+const VALUE_COUNT_BEFORE_TIRE_PROFILE_UPDATE = 98;
+const VALUE_COUNT_BEFORE_MOTOR_AND_BATTERY_UPDATE = 100;
+const TIRE_PROFILE_SIZE_INDEX = 39;
+const MOTOR_AND_BATTERY_INDEX = 24;
+
 export interface FormEncoderOptions {
   getDefaultForm(): GenericForm;
   serialize?: (flattenedObj: FlattenedObject) => string;
@@ -155,32 +160,26 @@ function serializeFlatObject(flattenedObj: FlattenedObject): string {
 function deserializeFlatObject(value: string, flattenedKeys: string[]): FlattenedObject {
   const values = JSON.parse(value) as never[];
 
-  if (values.length !== flattenedKeys.length) {
-    throw new Error('Invalid form');
+  /**
+   * Added Tire Profile Size
+   * If a link is before this was added, we need to
+   * insert the values into the parsed array
+   */
+  if (values.length === VALUE_COUNT_BEFORE_TIRE_PROFILE_UPDATE) {
+    values.splice(TIRE_PROFILE_SIZE_INDEX, 0, 's' as never, 's' as never);
+  }
+
+  /**
+   * Added Motor and Battery
+   */
+  if (values.length === VALUE_COUNT_BEFORE_MOTOR_AND_BATTERY_UPDATE) {
+    values.splice(MOTOR_AND_BATTERY_INDEX, 0, 'na' as never);
   }
 
   const flattenedForm: FlattenedObject = {};
   flattenedKeys.forEach((key, index) => {
     flattenedForm[key] = unmangleValue(values[index]) as never;
   });
-  return flattenedForm;
-}
 
-export function deserializeFlatObjectV1(value: string, flattenedKeys: string[]): Record<string, never> {
-  const values = JSON.parse(value) as never[];
-
-  /**
-   * Added Tire Profile Size
-   * If a link is before this was added, we need to
-   * insert the values into the parsed array
-   */
-  if (values.length === 98) {
-    values.splice(38, 0, 's' as never, 's' as never);
-  }
-
-  const flattenedForm: Record<string, never> = {};
-  flattenedKeys.forEach((key, index) => {
-    flattenedForm[key] = unmangleValue(values[index]) as never;
-  });
   return flattenedForm;
 }


### PR DESCRIPTION
- Fixed spring rate conversion
- Added "Motor and Battery"
- Added Discord formatting
- Removed obsolete transmission upgrade options
- Removed a "stray" element that showed the rear weight distribution
- Adjusted Discord formatting to always show the car's stats in metric first, then imperial (It was showing the weight in lbs first, then kg)
- Changed order of "Drivetrain" section inputs to reflect in game menu
- Changed order of "Tires" section inputs to reflect in game menu
- Changed order of "Aero and Appearance"  section inputs to reflect in game menu
- Changed order of "Conversions" section inputs to reflect in game menu
